### PR TITLE
Unicode

### DIFF
--- a/lib/rack/signature.rb
+++ b/lib/rack/signature.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require_relative 'signature/version'
 require_relative 'signature/build_post_body'
 require_relative 'signature/build_message'

--- a/lib/rack/signature/build_post_body.rb
+++ b/lib/rack/signature/build_post_body.rb
@@ -12,7 +12,7 @@ module Rack
       end
 
       def sorted_json
-        sort_post_body.to_json
+        JSON.generate(sort_post_body)
       end
 
       def sort_post_body

--- a/lib/rack/signature/test_helpers.rb
+++ b/lib/rack/signature/test_helpers.rb
@@ -2,6 +2,7 @@ require_relative 'build_message'
 require_relative 'hmac_signature'
 require_relative 'sort_query_params'
 require 'rack'
+require 'json'
 
 module Rack
   module Signature
@@ -9,6 +10,15 @@ module Rack
 
       def convert_hash_to_string(params)
         params.map { |p| p.join('=')}.join('&')
+      end
+
+      def hash_to_sorted_json(obj)
+        sorted_hash = SortQueryParams.new(obj).order
+        JSON.generate(sorted_hash)
+      end
+
+      def sorted_json_to_hash(obj)
+        JSON.parse(obj)
       end
 
       def stringify_request_message(env)

--- a/lib/rack/signature/verify.rb
+++ b/lib/rack/signature/verify.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require_relative 'hmac_signature'
 
 # A Rack app to verify requests based on a computed signature passed within the
@@ -32,7 +33,7 @@ module Rack
         else
           status, headers, body = @app.call(env)
           body.close if body.respond_to?(:close)
-          [401, {'CONTENT_TYPE' => 'application/json'}, ['Access Denied']]
+          [401, {'CONTENT_TYPE' => 'application/json', :charset => 'utf-8'}, ['Access Denied']]
         end
       end
 

--- a/lib/rack/signature/version.rb
+++ b/lib/rack/signature/version.rb
@@ -2,7 +2,7 @@ module Rack
   module Signature
     MAJOR = 0
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
 
     def self.version
       [MAJOR, MINOR, PATCH].join('.')

--- a/rack-signature.gemspec
+++ b/rack-signature.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'active_support'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'minitest/autorun'
 require 'rack/test'
 require 'rack/mock'


### PR DESCRIPTION
this has always supported unicode (utf-8), but using #to_json in the context of Rails (3.2.10) would encode the json. This was causing issues when signing requests because the json data is signed with utf-8 characters and the verified with encoded utf-8 characters; thus signatures would not match
